### PR TITLE
Use php://temp instead of tmpfile(). #performance

### DIFF
--- a/Stringbuffer.php
+++ b/Stringbuffer.php
@@ -117,7 +117,7 @@ abstract class Stringbuffer
      */
     protected function &_open ( $streamName, \Hoa\Stream\Context $context = null ) {
 
-        if(false === $out = @tmpfile())
+        if(false === $out = @fopen('php://temp', 'w+b'))
             throw new Exception(
                 'Failed to open a string buffer.', 0);
 


### PR DESCRIPTION
Because php://temp starts by placing the content of the stream in the memory before reaching a certain size and therefore switching to a real file, we can save a lot of I/O here!
